### PR TITLE
Added operator overloading methods to address #14

### DIFF
--- a/timeseries/Timeseries.py
+++ b/timeseries/Timeseries.py
@@ -1,5 +1,6 @@
 import lazy
 import numpy as np
+import numbers
 
 class TimeSeries:
     def __init__(self, values, times=None):
@@ -391,4 +392,93 @@ class TimeSeries:
 
         return self.identity()
     
+    def __pos__(self):
+        #TimeSeries instance with
+        # no change to the values or times
+        return self
+        
+    def __neg__(self):
+        # TimeSeries instance with
+        # negated values 
+        # and no change to the times
+        cls = type(self)
+        return cls((-v for v in self._values),self._times)
+        
+    def __abs__(self):
+        # TimeSeries instance with 
+        # absolute value of the values
+        # and no change to the times
+        cls = type(self)
+        return cls((abs(v) for v in self._values),self._times)
+    
+    def __bool__(self):
+        # False only if all values are zero
+        return bool(any(self._values))
+        
+    def __add__(self, rhs):
+        # If rhs is Real, add it to all elements of values.
+        # If it is a TimeSeries instance with the same times,
+        # add it element-by-element.
+        # Return a TimeSeries instance with the same times but the new values
+        cls = type(self)
+        try:
+            if isinstance(rhs, numbers.Real):
+                return cls((a + rhs for a in self._values),self._times) 
+            elif isinstance(rhs,cls):
+                if (len(self)==len(rhs)) and self._eqtimes(rhs): 
+                    return cls((a + b for a, b in zip(self._values,rhs._values)),self._times)
+                else:
+                    raise ValueError(str(self)+' and '+str(rhs)+' must have the same time points')
+            else:
+                return NotImplemented
+        except TypeError:
+            return NotImplemented
+            
+    def __sub__(self, rhs):
+        # If rhs is Real, subtract it from all elements of values.
+        # If it is a TimeSeries instance with the same times,
+        # subtract it element-by-element.
+        # Return a TimeSeries instance with the same times but the new values
+        try:
+            return self + (-rhs)
+        except TypeError:
+            return NotImplemented
+    
+    def __mul__(self, rhs):
+        # If rhs is Real, multiply it by all elements of values.
+        # If it is a TimeSeries instance with the same times,
+        # multiply it element-by-element.
+        # Return a TimeSeries instance with the same times but the new values
+        cls = type(self)
+        try:
+            if isinstance(rhs, numbers.Real):
+                return cls((a*rhs for a in self._values),self._times) 
+            elif isinstance(rhs,cls):
+                if (len(self)==len(rhs)) and self._eqtimes(rhs): 
+                    return cls((a*b for a, b in zip(self._values,rhs._values)),self._times)
+                else:
+                    raise ValueError(str(self)+' and '+str(rhs)+' must have the same time points')
+            else:
+                return NotImplemented
+        except TypeError:
+            return NotImplemented
+    
+    def _eqtimes(self,rhs):
+        # Test equality of the time components of two TimeSeries instances
+        return len(self._times)==len(rhs._times) and all(a==b for a,b in zip(self._times,rhs._times))
 
+    def _eqvalues(self,rhs):
+        # Test equality of the values components of two TimeSeries instances
+        return len(self._values)==len(rhs._values) and all(a==b for a,b in zip(self._values,rhs._values))
+        
+    def __eq__(self,rhs):
+        # True if the times and values are the same; 
+        # Otherwise, False
+        cls = type(self)
+        if isinstance(rhs, cls):
+            return self._eqtimes(rhs) and self._eqvalues(rhs)
+        #elif isinstance(rhs, numbers.Real):
+        #    return all(v==rhs for v in self._values)
+        else:
+            return False
+            

--- a/timeseries/test_Timeseries.py
+++ b/timeseries/test_Timeseries.py
@@ -19,3 +19,95 @@ def test_lazy_smoketest():
     thunk = check_length(TimeSeries(range(0,4),range(1,5)).lazy, TimeSeries(range(1,5),range(2,6)).lazy)
     assert thunk.eval()==True
 
+def test_pos():
+    # Values should be the same
+    assert (+ts)._values==ts._values
+    # Times should be the same
+    assert (+ts)._times==list(ts._times)
+    # A new instance should be created that is equal to the old.
+    assert +ts==ts
+    
+def test_neg():
+    # Values should be negated
+    assert (-ts)._values==[-v for v in ts._values]
+    # Times should be the same
+    assert (-ts)._times==list(ts._times)
+    # Negating twice should return to the start
+    assert -(-ts)==ts
+    
+def test_abs():
+    # absolute value of an instance with negative and positive values
+    # should have only positive values
+    ts2 = TimeSeries(range(-10,10))
+    assert min(abs(ts2)._values)>=0
+    # Times should be the same
+    assert abs(ts2)._times == list(ts2._times)
+
+def test_eq():
+    ts3 = TimeSeries(range(10))
+    ts4 = TimeSeries(range(10))
+    ts5 = TimeSeries(range(9))
+    assert ts3==ts4
+    assert ts3 is not ts4
+    assert ts3!=ts5
+    
+def test_bool():
+    assert not bool(TimeSeries([0,0,0]))
+    assert bool(TimeSeries([0,0,1]))
+    assert bool(TimeSeries([-1,0,0]))
+    
+    
+def test_add():
+    ts_long = TimeSeries(range(9))
+    assert ts+ts==TimeSeries((2*v for v in ts._values),ts._times)
+    # Addition with a constant is defined
+    assert ts+5==TimeSeries((5+v for v in ts._values),ts._times)
+    # Different-length timeseries should return a value error
+    with raises(ValueError):
+        ts+ts_long
+    # Time series with different values should return a value error
+    with raises(ValueError):
+    
+        ts+TimeSeries(range(0,4),range(0,4))
+    # addition with other types is not implemented    
+    with raises(TypeError):
+        assert ts+'a'
+    with raises(TypeError):
+        assert 'a'+ts
+            
+def test_sub():
+    ts_long = TimeSeries(range(9))
+    assert ts-ts==TimeSeries((0 for v in ts._values),ts._times)
+    assert ts-ts==ts+(-ts)
+    # Subtraction with a constant is defined
+    assert ts-5==TimeSeries((v-5 for v in ts._values),ts._times)
+    # Different-length timeseries should return a value error
+    with raises(ValueError):
+        ts-ts_long
+    # Time series with different values should return a value error
+    with raises(ValueError):
+        ts-TimeSeries(range(0,4),range(0,4))
+    # subtraction with other types is not implemented    
+    with raises(TypeError):
+        assert ts-'a'
+    with raises(TypeError):
+        assert 'a'-ts
+
+def test_mul():
+    ts_long = TimeSeries(range(9))
+    assert ts*ts==TimeSeries((v**2 for v in ts._values),ts._times)
+    # Multiplication with a constant is defined
+    assert ts*5==TimeSeries((5*v for v in ts._values),ts._times)
+    # Different-length timeseries should return a value error
+    with raises(ValueError):
+        ts*ts_long
+    # Time series with different values should return a value error
+    with raises(ValueError):
+        ts*TimeSeries(range(0,4),range(0,4))
+    # multiplication with other types is not implemented    
+    with raises(TypeError):
+        assert ts*'a'
+    with raises(TypeError):
+        assert 'a'*ts
+    
+


### PR DESCRIPTION
Added to TimeSeries, the methods:
__pos__
__neg__
__abs__
__bool__

__add__
__sub__
__mul__
__eq__

as well as the following two supporting methods:
_eqtimes
_eqvalues

I also updated the testing file to test these additions.

```
modified:   timeseries/Timeseries.py
modified:   timeseries/test_Timeseries.py
```
