### PR TITLE
#35 Fixed TimeSeries constructor

### DIFF
--- a/timeseries/ArrayTimeSeries.py
+++ b/timeseries/ArrayTimeSeries.py
@@ -10,32 +10,7 @@ class ArrayTimeSeries(TimeSeries):
     values : a sequence- data used to populate time series instance.
     times  : a sequence- time associated with each observation in `values`.
 
-    >>> threes=range(0,1000,3)
-    >>> times = range(0,1000,1)
-    >>> ap=ArrayTimeSeries(times,threes)
-    >>> ap[0] = 999
-    >>> ap[0]
-    999
-    >>> repr(ap)
-    'ArrayTimeSeries(Length: 334, Times: array([  0,  ...97, 998, 999]), Values: array([999,  ...93, 996, 999]))'
-    >>> print(ap)
-    ArrayTimeSeries with 334 elements (Times: array([  0,  ...97, 998, 999]), Values: array([999,  ...93, 996, 999]))
-    >>> len(ap)
-    334
-    >>> ap = ap=ArrayTimeSeries([0,1,2,3],[5,6,7,8])
-    >>> list(iter(ap))
-    [5, 6, 7, 8]
-    >>> list(ap.itertimes())
-    [0, 1, 2, 3]
-    >>> list(ap.iteritems())
-    [(0, 5), (1, 6), (2, 7), (3, 8)]
-
-    #Now test non-uniform time series
-    >>> a = ArrayTimeSeries(times=[1,2.5,3,3.5,4],values=[0,5,10,8,7], )
-    >>> a
-    ArrayTimeSeries(Length: 5, Times: array([ 1. , ...,  3.5,  4. ]), Values: array([ 0,  5, 10,  8,  7]))
-    >>> print(a)
-    ArrayTimeSeries with 5 elements (Times: array([ 1. , ...,  3.5,  4. ]), Values: array([ 0,  5, 10,  8,  7]))
+   
 
     """
     def __init__(self,times,values):
@@ -68,13 +43,3 @@ class ArrayTimeSeries(TimeSeries):
         return super().iteritems()
 
 
-
-#threes=range(0,1000,3)
-#times = range(0,1000,1)
-#ap=ArrayTimeSeries(times,threes)
-#ap[0] = 999
-#ap[0]
-##999
-#print("HERE",repr(ap))
-##ArrayTimeSeries(Length: 334, Times: array([  0,  ...97, 998, 999]), Values: array([999,  ...93, 996, 999]))
-#print(ap)

--- a/timeseries/Timeseries.py
+++ b/timeseries/Timeseries.py
@@ -9,6 +9,10 @@ class TimeSeries:
     Purpose of the class.
     Things the user should keep in mind when using an instance
         of this object.
+        
+    Notes:
+    ------
+    PRE: times must be a monotonically increasing sequence 
     """
 
     def __init__(self, values, times=None):
@@ -19,10 +23,6 @@ class TimeSeries:
            data used to populate time series instance.
         times  : a sequence (optional)
            time associated with each observation in `values`.
-        
-        Notes:
-        ------
-        PRE: times (if provided) must be montonically increasing
 
         """
         #test whether values is a sequence
@@ -30,6 +30,8 @@ class TimeSeries:
             iter(values)
         except TypeError:
             raise TypeError("Non sequence passed into constructor")
+        self._values = [x for x in values]
+        
                 
         if times == None:
             self._times = range(0,len(values))
@@ -38,27 +40,13 @@ class TimeSeries:
             try:
                 iter(times)
                 self._times = [x for x in times]
+                if len(self._times) != len(self._values):
+                    raise TypeError("Times and Values must be same length")                
             except TypeError:
                 raise TypeError("Non sequence passed into constructor")            
-        
-        #check monotonically inceasing
-        seen = set()
-        try:
-            maxval = self._times[0]
-        except:
-            maxval = None
-            
-        for x in self._times:
-            if x in seen or x < maxval:
-                raise TypeError("Times must be a monotonically increasing container")  
-            elif x not in seen:
-                seen.add(x) 
-                if x > maxval:
-                    maxval = x
             
         
-        self._values = [x for x in values]
-
+        
 
     def __len__(self):
         return len(self._values)
@@ -157,7 +145,6 @@ class TimeSeries:
         
         """
         
-        times_to_interpolate = sorted(times_to_interpolate)
         tms = []
         def interp_helper(t):
             tms.append(t)

--- a/timeseries/test_Timeseries.py
+++ b/timeseries/test_Timeseries.py
@@ -68,13 +68,10 @@ class TimeSeriesTest(unittest.TestCase):
     def tearDown(self):
         del self.ts
         
-    def test_input_monotone_increasing(self):
+    def test_input_diff_len(self):
         with raises(TypeError):
-            t = TimeSeries([1,2,3],[3,1,3])
-        with raises(TypeError):
-            t = TimeSeries([1,2,3],[3,1,4])
+            t = TimeSeries([1,2,3],[3,1,3,4])
             
-
     def test_input_range(self):
         t = TimeSeries(range(0,5))
 


### PR DESCRIPTION
Changed the TimeSeries constructor based on our meeting consensus. TimeSeries has the precondition that times is a monotonically increasing sequence and we don't explicitly check for this behavior. We do ensure that times and values are sequences and that they have the same length (if any of these checks fail, a TypeError with message is raised).

Removed sort inside Interpolate function as this is unnecessary. 
