### PR TITLE
#40 Rewrite ArrayTimeSeries to take advantage of np storage, rewrite tests

### DIFF
--- a/timeseries/ArrayTimeSeries.py
+++ b/timeseries/ArrayTimeSeries.py
@@ -1,5 +1,6 @@
 from Timeseries import TimeSeries
 import numpy as np
+import numbers
 
 class ArrayTimeSeries(TimeSeries):
     """
@@ -10,36 +11,165 @@ class ArrayTimeSeries(TimeSeries):
     values : a sequence- data used to populate time series instance.
     times  : a sequence- time associated with each observation in `values`.
 
-   
-
+    Notes:
+    ------
+    PRE: times must be a monotonically increasing sequence
+    
     """
     def __init__(self,times,values):
-        TimeSeries.__init__(self,values,times)
-        self._times = np.array(times)
-        self._values = np.array(values)
+        """
+        Parameters
+        ----------
+        times  : a sequence 
+           time associated with each observation in `values`.
+        values : a sequence
+           data used to populate time series instance.
+        
+        Examples:
+        --------
+        >>> ats = ArrayTimeSeries(times=[0,1,2],values=[10,20,30])
+        """
+        
+        #test whether values is a sequence
+        try:
+            self._times = np.array([_ for _ in times])
+            self._values = np.array([_ for _ in values])
+        except TypeError:
+            raise TypeError("Non sequence passed into constructor")
+        
+        #make sure that times and values are the same length
+        if np.size(self._times) != np.size(self._values):
+            raise TypeError("Times and Values must be same length")           
+       
 
     def __getitem__(self,index):
         try:
-            return self._values[index]
+            return np.take(self._values,index) #faster than regular indexing
         except IndexError:
             raise IndexError("Index out of bounds")
 
     def __setitem__(self,index,value):
         try:
-            self._values[index] = value
+            np.put(self._values, index, value)
         except IndexError:
             raise IndexError("Index out of bounds")
 
     def __len__(self):
-        return super().__len__()
+        return np.size(self._values)    
+    
+    def values(self):
+        #returns a numpy array of values
+        return self._values
+    
+    def times(self):
+        #returns a numpy array of times
+        return self._times
+    
+    def interpolate(self,times_to_interpolate):
+        """
+        Produces new TimeSeries with linearly interpolated values using
+        piecewise-linear functions with stationary boundary conditions.
+        Uses the numpy searchsorted() function.
+        
+        Parameters:
+        -----------
+        self: TimeSeries instance
+        times_to_interpolate: sorted sequence of times to be interpolated
+        
+        Returns:
+        --------
+        TimeSeries instance with interpolated times
+        
+        Examples:
+        --------
+        >>> ats = ArrayTimeSeries(times=[0,1,2],values=[40,20,30])
+        >>> ats.interpolate([0.5,1.5,3])
+        ArrayTimeSeries(Length: 3, Times: array([ 0.5,  1.5,  3. ]), Values: array([ 30.,  25.,  30.]))
+        
+        """
+        
+        def binary_search_np(times,t):
+            #Uses numpy searchsorted to perform binary search
+            idx = np.searchsorted(times,t)
+            if np.take(times,idx) == t:
+                return self._values[t]
+            else:
+                left_idx,right_idx = idx-1, idx
+                m = float(self._values[right_idx]-self._values[left_idx])/(self._times[right_idx]-self._times[left_idx])
+                return (t-self._times[left_idx])*m + self._values[left_idx]                
 
-    def __iter__(self):
-        return super().__iter__()
+        tms = []
+        def interp_helper(t):
+            #Interpolates a given time value
+            tms.append(t)
+            #if the time is less than all the times we have
+            if t <= self._times[0]:
+                return self._values[0]
+            #if the time is greater than all the times we have
+            elif t >= self._times[-1]:
+                return self._values[-1]
+            else:
+                return binary_search_np(self._times,t)
+        
+        interpolated_values = [interp_helper(t) for t in times_to_interpolate] 
+        return self.__class__(times=tms, values=interpolated_values)
+    
 
-    def itertimes(self):
-        return super().itertimes()
+    def __neg__(self):
+        # returns: TimeSeries instance with negated values and no change to the times
+        cls = type(self)
+        return cls(self._times,self._values*-1)
 
-    def iteritems(self):
-        return super().iteritems()
 
+    def __abs__(self):
+        # returns: new TimeSeries instance with absolute value of the values
+        # and no change to the times
+        cls = type(self)
+        return cls(self._times,abs(self._values))
+
+
+    def __bool__(self):
+        # returns: bool `False` iff all `_values` are zero
+        return np.count_nonzero(self._values) > 0   
+    
+    
+    def __add__(self, rhs):
+        # if rhs is Real, add it to all elements of `_values`.
+        # if rhs is a TimeSeries instance with the same times, add it element-by-element.
+        # returns: a new TimeSeries instance with the same times but updated `_values`.
+        cls = type(self)
+        if isinstance(rhs, numbers.Real):
+            return cls(values=self._values+rhs,times=self._times)
+        elif isinstance(rhs,cls):
+            if (len(self)==len(rhs)) and self._eqtimes(rhs):
+                return cls(values=self._values+rhs._values,times=self._times)
+            else:
+                raise ValueError(str(self)+' and '+str(rhs)+' must have the same time points.')
+        else:
+            return NotImplemented  
+        
+    
+    def __mul__(self, rhs):
+        # if rhs is Real, multiply it by all elements of `_values`.
+        # if rhs is a TimeSeries instance with the same times, multiply it element-by-element.
+        # returns: a new TimeSeries instance with the same times but updated `_values`.
+        cls = type(self)
+        if isinstance(rhs, numbers.Real):
+            return cls(values=rhs*self._values,times=self._times)
+        elif isinstance(rhs,cls):
+            if (len(self)==len(rhs)) and self._eqtimes(rhs):
+                return cls(values=self._values*rhs._values,times=self._times)
+            else:
+                raise ValueError(str(self)+' and '+str(rhs)+' must have the same time points')
+        else:
+            return NotImplemented
+        
+    def _eqtimes(self,rhs):
+        # test equality of the time components of two TimeSeries instances
+        return np.array_equal(self._times, rhs._times)
+    
+    def _eqvalues(self,rhs):
+        # test equality of the values components of two TimeSeries instances
+        return np.array_equal(self._values, rhs._values)
+       
 

--- a/timeseries/Timeseries.py
+++ b/timeseries/Timeseries.py
@@ -45,8 +45,6 @@ class TimeSeries:
             except TypeError:
                 raise TypeError("Non sequence passed into constructor")            
             
-        
-        
 
     def __len__(self):
         return len(self._values)
@@ -103,7 +101,6 @@ class TimeSeries:
 
     def __contains__(self,item):
         return item in self._values
-         
 
     def itertimes(self):
         for i in self._times:


### PR DESCRIPTION
These are the changes in ArrayTimeSeries:
1. init(): now checks sizes of times and values
2. getitem(): uses np.take() which is faster than regular indexing (says the internet)
3. setitem(): uses np.put() likewise faster than regular indexing/setting
4. len(): uses np.size()
5. values: just returns the values (doesn't need to cast into a np array again)
6. times: just returns the times (doesn't need to cast into a np array again)
7. interpolate: now uses np.searchsorted() instead of the binary_search code
8. neg(): uses numpy multiplication
9. abs(): uses numpy absolute value
10. bool(): uses np.count_nonzero()
11. add(): uses numpy addition
12. mul(): uses numpy multiplication
13. eqtimes(): uses np.array_equal()
14. eqvalues(): uses np.array_equal()

Functions omitted (should just inherit these from the parent because I can't find a faster way to implement them):
1. repr()
2. str()
3. iter()
4. contains()
5. itertimes()
6. iteritems()
7. itervalues()
8. items()
9. identity()
10. lazy()
11. pos()
12. sub()
13. eq()

@brennan-ae See anything on this bottom list that you think could be sped up? I was unsure whether I should use the numpy iterator?
