### PR TITLE
Updated FileStorageManager functionality

### DIFF
--- a/timeseries/StorageManager.py
+++ b/timeseries/StorageManager.py
@@ -47,8 +47,8 @@ class FileStorageManager(StorageManagerInterface):
         self._dir = directory
         self._id = None
         self._idx_file = self._dir+'/index.p'
-        with open(self._idx_file,'wb') as f:
-            pickle.dump(self._index,f)
+        #with open(self._idx_file,'wb') as f:
+        #    pickle.dump(self._index,f)
         
     @staticmethod
     def _make_ts(ts):


### PR DESCRIPTION
It is now possible to open a new FileStorageManager and load the index of the existing manager in that directory.  This gives the new storage manager access to the existing index.

However, the two managers are now competing for the same index file and are overwriting each other's changes without communicating. This is a problem.  This change is meant to allow a new manager to read the files from another manager then exit without modifying anything.